### PR TITLE
Fix the read_preference context manager when not has_request_context()

### DIFF
--- a/flask_mongoengine/context_managers.py
+++ b/flask_mongoengine/context_managers.py
@@ -4,19 +4,21 @@ from mongoengine.queryset.queryset import QuerySet
 orig_cursor_args = QuerySet._cursor_args.fget
 
 # In case we're not in a request context
-_read_preference = None
+class local_cache(object):
+    read_preference = None
+cache = local_cache()
 
 def _get_read_preference():
     if has_request_context():
         return getattr(g, 'read_preference', None)
     else:
-        return _read_preference
+        return cache.read_preference
 
 def _set_read_preference(val):
     if has_request_context():
         g.read_preference = val
     else:
-        _read_preference = val
+        cache.read_preference = val
 
 
 def _patched_cursor_args(self):


### PR DESCRIPTION
FYI @thomasst this never worked: https://github.com/closeio/flask-mongoengine/blame/master/flask_mongoengine/context_managers.py#L7. As a refresher:

```
In [1]: _read_pref = None

In [2]: def set_read_pref(val):
   ...:     _read_pref = val
   ...:

In [3]: _read_pref

In [4]: set_read_pref(1)

In [5]: _read_pref

```